### PR TITLE
New RegisterInstance method

### DIFF
--- a/Scripts/Runtime/Core/ServiceLocator.cs
+++ b/Scripts/Runtime/Core/ServiceLocator.cs
@@ -37,10 +37,15 @@ namespace BrunoMikoski.ServicesLocation
         public void RegisterInstance<T>(T serviceInstance)
         {
             Type type = typeof(T);
-            RegisterInstance(type, serviceInstance);
+            RegisterInstanceInternal(type, serviceInstance);
         }
 
-        private void RegisterInstance(Type type, object serviceInstance, bool tryResolveDependencies = true)
+        public void RegisterInstance(Type type, object serviceInstance)
+        {
+            RegisterInstanceInternal(type, serviceInstance);
+        } 
+
+        private void RegisterInstanceInternal(Type type, object serviceInstance, bool tryResolveDependencies = true)
         {
             if (!CanRegisterService(type, serviceInstance))
                 return;
@@ -281,7 +286,7 @@ namespace BrunoMikoski.ServicesLocation
             foreach (var resolvedTypeToObj in resolvedDependencies)
             {
                 servicesWaitingOnDependenciesTobeResolved.Remove(resolvedTypeToObj.Key);
-                RegisterInstance(resolvedTypeToObj.Key, resolvedTypeToObj.Value, false);
+                RegisterInstanceInternal(resolvedTypeToObj.Key, resolvedTypeToObj.Value, false);
                 anyNewServiceRegistered = true;
             }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.brunomikoski.servicelocator",
     "displayName": "Service Locator",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "unity": "2021.3",
     "description": "",
     "keywords": [


### PR DESCRIPTION
Hi!

I've added new `public void RegisterInstance(Type type, object serviceInstance)` method to the ServiceLocator which would allow to register services with an additional layer of abstraction. Consider the following example:

```
public interface IServiceProvider
{
    Type Type { get; }
    object Instance { get; }
}

...

var serviceProviders = new List<IServiceProvider>();

foreach (IServiceProvider serviceProvider in serviceProviders)
{
    ServiceLocator.Instance.RegisterInstance(serviceProvider.Type, serviceProvider.Instance);
}
```

Let me know what you think!

I've also increased the package version, since it would be great if you could publish this change on openupm as well.