### PR TITLE
Fix issues using [RuntimeInitializeOnLoadMethod] on generic classes

### DIFF
--- a/Scripts/Editor/Core/SingletonResetter.cs
+++ b/Scripts/Editor/Core/SingletonResetter.cs
@@ -1,0 +1,35 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Scripting;
+using System.Reflection;
+
+namespace BrunoMikoski.ServicesLocation
+{
+    public static class SingletonResetter
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetAllSingletons()
+        {
+            // Find all types that inherit from SingletonMonoBehaviour<>
+            UnityEditor.TypeCache.TypeCollection singletonTypes = TypeCache.GetTypesDerivedFrom(typeof(SingletonMonoBehaviour<>));
+
+            // Reset all instances
+            string typeLog = string.Empty;
+            foreach (System.Type type in singletonTypes)
+            {
+                typeLog += $"\t{type.ToString()}\n";
+                MethodInfo method = type.GetMethod("ResetSingleton", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+                if (method != null)
+                {
+                    method.Invoke(null, null);
+                }
+                else
+                {
+                    Debug.LogError($"ResetAllSingletons: Can't find 'ResetSingleton' method on type '{type.ToString()}'");
+                }
+            }
+            Debug.Log($"ResetAllSingletons: The following derived instances of SingletonMonoBehaviour have been reset:\n{typeLog}");
+        }
+    }
+}

--- a/Scripts/Editor/Core/SingletonResetter.cs.meta
+++ b/Scripts/Editor/Core/SingletonResetter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97dc8a9f44d9319438d90bfbe9a4d5a1

--- a/Scripts/Runtime/Utils/SingletonMonoBehaviour.cs
+++ b/Scripts/Runtime/Utils/SingletonMonoBehaviour.cs
@@ -6,14 +6,13 @@ namespace BrunoMikoski.ServicesLocation
     [Preserve]
     public abstract class SingletonMonoBehaviour<T> : MonoBehaviour where T : Component
     {
-#if UNITY_EDITOR
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void Init()
+
+        // This method will be called by the static SingletonResetter script
+        public static void ResetSingleton()
         {
             instance = null;
             hasInstance = false;
         }
-#endif
 
         private static bool hasInstance;
         private static T instance;


### PR DESCRIPTION
Generic classes are unable to have any [RuntimeInitializeOnLoadMethod] tagged functions because they don't have a specific class definition yet.

To get around this I've added a 'ResetSingleton' function to the generic class which each derived class inherits. I've also added an Editor only 'SingletonResetter' static class that will find all current derived instances of SingletonMonoBehaviour and reset them (when domain reloading is disabled)

I've tested this and it resets ok, here's the current debug log:

ResetAllSingletons: The following derived instances of SingletonMonoBehaviour have been reset:
	BrunoMikoski.ServicesLocation.ServiceLocator